### PR TITLE
Add JavaFX graph visualizer for IndoorGML

### DIFF
--- a/beispiel/src/GraphApp.java
+++ b/beispiel/src/GraphApp.java
@@ -1,0 +1,63 @@
+package beispiel;
+
+import javafx.application.Application;
+import javafx.geometry.Point2D;
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.Line;
+import javafx.scene.text.Text;
+import javafx.stage.Stage;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * JavaFX application that visualizes an IndoorGML graph.
+ */
+public class GraphApp extends Application {
+
+    @Override
+    public void start(Stage stage) throws Exception {
+        String filePath = getParameters().getUnnamed().isEmpty()
+                ? "indoor.gml"
+                : getParameters().getUnnamed().get(0);
+        IndoorGMLGraph graph = IndoorGMLGraph.fromFile(new File(filePath));
+
+        Pane root = new Pane();
+        int n = graph.getNodes().size();
+        double centerX = 300;
+        double centerY = 300;
+        double radius = 250;
+
+        Map<IndoorGMLGraph.GraphNode, Point2D> positions = new HashMap<>();
+        for (int i = 0; i < n; i++) {
+            IndoorGMLGraph.GraphNode node = graph.getNodes().get(i);
+            double angle = 2 * Math.PI * i / n;
+            double x = centerX + radius * Math.cos(angle);
+            double y = centerY + radius * Math.sin(angle);
+            positions.put(node, new Point2D(x, y));
+            Circle circle = new Circle(x, y, 15);
+            Text text = new Text(x - 10, y - 20, node.label);
+            root.getChildren().addAll(circle, text);
+        }
+
+        for (IndoorGMLGraph.GraphEdge edge : graph.getEdges()) {
+            Point2D p1 = positions.get(edge.from);
+            Point2D p2 = positions.get(edge.to);
+            if (p1 != null && p2 != null) {
+                Line line = new Line(p1.getX(), p1.getY(), p2.getX(), p2.getY());
+                root.getChildren().add(0, line);
+            }
+        }
+
+        stage.setScene(new Scene(root, 600, 600));
+        stage.setTitle("IndoorGML Graph");
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/beispiel/src/IndoorGMLGraph.java
+++ b/beispiel/src/IndoorGMLGraph.java
@@ -1,0 +1,136 @@
+package beispiel;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple representation of a graph derived from an IndoorGML file.
+ */
+public class IndoorGMLGraph {
+
+    /** Representation of a cell space node in the graph. */
+    public static class GraphNode {
+        public final String id;
+        public final String label;
+
+        public GraphNode(String id, String label) {
+            this.id = id;
+            this.label = label;
+        }
+    }
+
+    /** Representation of an edge between two cell spaces. */
+    public static class GraphEdge {
+        public final GraphNode from;
+        public final GraphNode to;
+
+        public GraphEdge(GraphNode from, GraphNode to) {
+            this.from = from;
+            this.to = to;
+        }
+    }
+
+    private final List<GraphNode> nodes = new ArrayList<>();
+    private final List<GraphEdge> edges = new ArrayList<>();
+
+    public List<GraphNode> getNodes() {
+        return nodes;
+    }
+
+    public List<GraphEdge> getEdges() {
+        return edges;
+    }
+
+    /**
+     * Parses an IndoorGML file and builds a graph consisting of cell spaces and transitions.
+     */
+    public static IndoorGMLGraph fromFile(File file) throws Exception {
+        IndoorGMLGraph graph = new IndoorGMLGraph();
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder builder = dbf.newDocumentBuilder();
+        Document doc = builder.parse(file);
+
+        String gmlNs = "http://www.opengis.net/gml/3.2";
+        String xlinkNs = "http://www.w3.org/1999/xlink";
+
+        // Parse cell spaces and create graph nodes
+        Map<String, GraphNode> cellMap = new HashMap<>();
+        NodeList cellSpaces = doc.getElementsByTagNameNS("*", "CellSpace");
+        for (int i = 0; i < cellSpaces.getLength(); i++) {
+            Element cs = (Element) cellSpaces.item(i);
+            String id = cs.getAttributeNS(gmlNs, "id");
+            if (id == null || id.isEmpty()) {
+                id = cs.getAttribute("id");
+            }
+            String label = id;
+            NodeList names = cs.getElementsByTagNameNS(gmlNs, "name");
+            if (names.getLength() > 0) {
+                label = names.item(0).getTextContent();
+            }
+            GraphNode node = new GraphNode(id, label);
+            graph.nodes.add(node);
+            cellMap.put(id, node);
+        }
+
+        // Map states to cell space nodes
+        Map<String, GraphNode> stateToNode = new HashMap<>();
+        NodeList states = doc.getElementsByTagNameNS("*", "State");
+        for (int i = 0; i < states.getLength(); i++) {
+            Element st = (Element) states.item(i);
+            String sid = st.getAttributeNS(gmlNs, "id");
+            if (sid == null || sid.isEmpty()) {
+                sid = st.getAttribute("id");
+            }
+            NodeList duals = st.getElementsByTagNameNS("*", "duality");
+            if (duals.getLength() > 0) {
+                Element dual = (Element) duals.item(0);
+                String href = dual.getAttributeNS(xlinkNs, "href");
+                if (href.startsWith("#")) {
+                    href = href.substring(1);
+                }
+                GraphNode node = cellMap.get(href);
+                if (node != null) {
+                    stateToNode.put(sid, node);
+                }
+            }
+        }
+
+        // Parse transitions and create edges between the connected cell spaces
+        NodeList transitions = doc.getElementsByTagNameNS("*", "Transition");
+        for (int i = 0; i < transitions.getLength(); i++) {
+            Element tr = (Element) transitions.item(i);
+            NodeList connects = tr.getElementsByTagNameNS("*", "connects");
+            GraphNode a = null;
+            GraphNode b = null;
+            for (int j = 0; j < connects.getLength(); j++) {
+                Element c = (Element) connects.item(j);
+                String href = c.getAttributeNS(xlinkNs, "href");
+                if (href.startsWith("#")) {
+                    href = href.substring(1);
+                }
+                GraphNode node = stateToNode.get(href);
+                if (node != null) {
+                    if (a == null) {
+                        a = node;
+                    } else if (b == null) {
+                        b = node;
+                        break;
+                    }
+                }
+            }
+            if (a != null && b != null) {
+                graph.edges.add(new GraphEdge(a, b));
+            }
+        }
+        return graph;
+    }
+}

--- a/beispiel/src/module-info.java
+++ b/beispiel/src/module-info.java
@@ -1,8 +1,5 @@
-/**
- * 
- */
-/**
- * 
- */
 module beispiel {
+    requires java.xml;
+    requires javafx.graphics;
+    exports beispiel;
 }


### PR DESCRIPTION
## Summary
- add IndoorGMLGraph utility to parse cell spaces and transitions into nodes and edges
- introduce GraphApp JavaFX UI to display cell-space graph
- update module configuration for JavaFX and XML support

## Testing
- `javac -d out beispiel/src/*.java` *(fails: module not found: javafx.graphics)*
- `apt-get update` *(fails: repository signatures / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af16e10c60832f90b053af6fbe7b22